### PR TITLE
Dependencies fix and Mai (miMatic) logo patch

### DIFF
--- a/aavealarm/Account.tsx
+++ b/aavealarm/Account.tsx
@@ -91,6 +91,8 @@ function AssetsTableRow(props: {
     iconName = iconName.slice(0, -2);
   } else if (iconName.startsWith("m.")) {
     iconName = iconName.slice(2);
+  } else if (iconName === "mimatic") {
+    iconName = "mai";
   }
   return (
     <View

--- a/aavealarm/package.json
+++ b/aavealarm/package.json
@@ -23,6 +23,7 @@
     "@react-navigation/native-stack": "^6.9.13",
     "@supabase/supabase-js": "^2.32.0",
     "big-integer": "^1.6.51",
+    "bignumber.js": "^9",
     "ethers": "^5.7.2",
     "ethjs-provider-http": "^0.1.6",
     "ethjs-query": "^0.3.8",
@@ -46,6 +47,7 @@
     "react-native-svg": "^13.11.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-uuid": "^2.0.1",
+    "reflect-metadata": "^0.1.13",
     "text-encoding": "^0.7.0",
     "text-encoding-polyfill": "^0.6.7"
   },


### PR DESCRIPTION
## Content :
### This pull request do the following:
- add already used dependencies to `package.json` (Sub-used by one of aave dependency but not install directly by running `yarn` / `npm install`) *
- fix Mai logo (currently the code assume asset logo can be load using `https://app.aave.com/icons/tokens/${assetName}.svg`. It's the case for most of Aave's assets yet it's not the case for Mai. Where assetName is mimatic but logo is link to assetName mai.

### App preview
#### Before :
<img width="327" alt="Capture d’écran 2023-09-14 à 00 28 46" src="https://github.com/nebolax/aavealarm/assets/11545946/2495989f-b358-4dce-a570-7a4c1b39b1a5">


#### After :
<img width="327" alt="Capture d’écran 2023-09-14 à 00 29 12" src="https://github.com/nebolax/aavealarm/assets/11545946/64b0a0ad-8af0-4e9f-8c02-485c09829cfd">


## Attention
*This works perfectly locally but please run app locally to double check it